### PR TITLE
Patch for Epoch times

### DIFF
--- a/ndustrialio/apiservices/__init__.py
+++ b/ndustrialio/apiservices/__init__.py
@@ -23,7 +23,7 @@ def get_epoch_time(dt_object):
     
     utc_1970 = datetime(1970, 1, 1).replace(tzinfo=pytz.utc)
     
-    return (delocalize_datetime(dt_object) - utc_1970).total_seconds()
+    return int(delocalize_datetime(dt_object) - utc_1970).total_seconds())
 
 
 

--- a/ndustrialio/apiservices/__init__.py
+++ b/ndustrialio/apiservices/__init__.py
@@ -3,12 +3,28 @@ import os
 from auth0.v2.authentication import Oauth
 import json
 from datetime import datetime
+import pytz
+from tzlocal import get_localzone
 
 API_VERSION = 'v1'
 
 BASE_URL = 'http://api.ndustrial.io'
 
 AUTH0_URL = 'ndustrialio.auth0.com'
+
+def delocalize_datetime(dt_object):
+    return dt_object.replace(tzinfo=get_localzone()).astimezone(pytz.utc)
+
+def get_epoch_time(dt_object):
+    if dt_object.tzinfo is None:
+        tz_aware_date = dt_object.replace(tzinfo=get_localzone())
+    else:
+        tz_aware_date = dt_object
+    
+    utc_1970 = datetime(1970, 1, 1).replace(tzinfo=pytz.utc)
+    
+    return (delocalize_datetime(dt_object) - utc_1970).total_seconds()
+
 
 
 class ApiClient(object):

--- a/ndustrialio/apiservices/rates.py
+++ b/ndustrialio/apiservices/rates.py
@@ -44,8 +44,8 @@ class RatesService(Service):
         assert isinstance(id, int)
         assert isinstance(timeStart, datetime)
         assert isinstance(timeEnd, datetime)
-        params['timeEnd'] = timeEnd.strftime('%s')
-        params['timeStart'] = timeStart.strftime('%s')
+        params['timeEnd'] = get_epoch_time(timeEnd)
+        params['timeStart'] = get_epoch_time(timeStart)
         
         return self.execute(GET(uri='schedules/{}/usage/periods'.format(id)).params(params), execute)
     
@@ -63,8 +63,8 @@ class RatesService(Service):
         assert isinstance(id, int)
         assert isinstance(timeStart, datetime)
         assert isinstance(timeEnd, datetime)
-        params['timeEnd'] = timeEnd.strftime('%s')
-        params['timeStart'] = timeStart.strftime('%s')
+        params['timeEnd'] = get_epoch_time(timeEnd)
+        params['timeStart'] = get_epoch_time(timeStart)
         
         return self.execute(GET(uri='schedules/{}/demand/periods'.format(id)).params(params), execute)
     

--- a/setup.py
+++ b/setup.py
@@ -8,4 +8,12 @@ setup(name='ndustrialio-python',
       author_email='jhunt@ndustrial.io',
       license='',
       packages=find_packages(),
+      install_requires=[
+        'pytz',
+        'tzlocal',
+        'requests'
+      ],
+      dependency_links=[
+        'git+https://git@github.com/ndustrialio/auth0-python.git'
+      ],
       zip_safe=False)


### PR DESCRIPTION
What?
Added methods that will take a timezone aware or a naive datetime object and return a proper UTC-based epoch seconds

Why?
Issues on windows system with `datetime.strftime('%s')` function
General assurances of proper utc epoch times