### PR TITLE
Add feeds batch call

### DIFF
--- a/ndustrialio/apiservices/feeds.py
+++ b/ndustrialio/apiservices/feeds.py
@@ -31,7 +31,7 @@ class FeedsService(Service):
 
         params = {"key": key}
 
-        return PagedResponse(self.execute(GET(uri='feeds').params(params), execute=execute))
+        return self.execute(GET(uri='feeds').params(params), execute=execute)
 
 
     def createFeed(self, key, timezone, type, facility_id, execute=True):
@@ -140,11 +140,18 @@ class FeedsService(Service):
         if time_end:
             params['timeEnd'] = str((time_end - datetime(1970,1,1)).total_seconds())
 
+        # TODO: remove this.  The caller should wrap response objects
+        if execute:
+            return DataResponse(data=self.execute(GET('outputs/{}/fields/{}/data'
+                                                      .format(output_id, field_human_name))
+                                                  .params(params), execute=True),
+                                client=self.client)
+        else:
+            return self.execute(GET('outputs/{}/fields/{}/data'
+                                                      .format(output_id, field_human_name))
+                                                  .params(params), execute=False)
 
-        return DataResponse(data=self.execute(GET('outputs/{}/fields/{}/data'
-                                .format(output_id, field_human_name))
-                                .params(params), execute=execute),
-                            client=self.client)
+
 
     def getOutputsForFacility(self, facility_id=None, limit=100, offset=0, execute=True):
 
@@ -154,7 +161,8 @@ class FeedsService(Service):
                     'limit': limit,
                   'offset': offset}
 
-        return PagedResponse(self.execute(GET(uri='outputs').params(params), execute=execute))
+
+        return self.execute(GET(uri='outputs').params(params), execute=execute)
 
     def getOutputs(self, id=None, limit=100, offset=0, execute=True):
 
@@ -193,6 +201,20 @@ class FeedsService(Service):
 
     def getLatestStatus(self, execute=True):
         return self.execute(GET('feeds/status/latest'), execute=execute)
+
+
+    def batch(self, api_requests):
+
+        batch_body = {}
+
+        i = 0
+
+        for api_request in api_requests:
+            batch_body['request_'+str(i)] = {'method': api_request.method(),
+                                             'uri': str(api_request)}
+            i+=1
+
+        return self.execute(POST(uri='batch').body(batch_body), execute=True)
     
     def getFieldDataMetrics(self, output_id_list, field_label, stale_seconds=None, start_time=None):
         

--- a/ndustrialio/apiservices/feeds.py
+++ b/ndustrialio/apiservices/feeds.py
@@ -31,8 +31,11 @@ class FeedsService(Service):
 
         params = {"key": key}
 
-        return self.execute(GET(uri='feeds').params(params), execute=execute)
+        if execute:
+            return PagedResponse(self.execute(GET(uri='feeds').params(params), execute=True))
 
+        else:
+            return self.execute(GET(uri='feeds').params(params), execute=False)
 
     def createFeed(self, key, timezone, type, facility_id, execute=True):
 
@@ -162,7 +165,11 @@ class FeedsService(Service):
                   'offset': offset}
 
 
-        return self.execute(GET(uri='outputs').params(params), execute=execute)
+        if execute:
+            return PagedResponse(self.execute(GET(uri='outputs').params(params), execute=True))
+
+        else:
+            return self.execute(GET(uri='outputs').params(params), execute=False)
 
     def getOutputs(self, id=None, limit=100, offset=0, execute=True):
 

--- a/ndustrialio/apiservices/feeds.py
+++ b/ndustrialio/apiservices/feeds.py
@@ -210,18 +210,18 @@ class FeedsService(Service):
         return self.execute(GET('feeds/status/latest'), execute=execute)
 
 
-    def batch(self, api_requests):
-
-        batch_body = {}
-
-        i = 0
-
-        for api_request in api_requests:
-            batch_body['request_'+str(i)] = {'method': api_request.method(),
-                                             'uri': str(api_request)}
-            i+=1
-
-        return self.execute(POST(uri='batch').body(batch_body), execute=True)
+    # def batch(self, api_requests):
+    #
+    #     batch_body = {}
+    #
+    #     i = 0
+    #
+    #     for api_request in api_requests:
+    #         batch_body['request_'+str(i)] = {'method': api_request.method(),
+    #                                          'uri': str(api_request)}
+    #         i+=1
+    #
+    #     return self.execute(POST(uri='batch').body(batch_body), execute=True)
     
     def getFieldDataMetrics(self, output_id_list, field_label, stale_seconds=None, start_time=None):
         


### PR DESCRIPTION
What:
Add batch call to feeds service

Why:
Increased flexibility

Notes:
I think the right thing to do is move any response wrappers to the caller of these methods.  The purpose of the `execute` default parameter is to enable easy batching, but that breaks in a way I don't have a clean solution for when response wrappers (`PagedResponse`, `DataResponse` are used. 