### PR TITLE
Remove scipy and numpy dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,6 @@ setup(name='ndustrialio-python',
         'pytz',
         'tzlocal',
         'requests',
-        'scipy',
-        'numpy'
       ],
       dependency_links=[
         'git+https://git@github.com/ndustrialio/auth0-python.git'


### PR DESCRIPTION
scipy and numpy are quite large dependencies. They were only used to compute
fairly simple histograms so compute those ourselves instead.

Testing done:

Added function (not included) that compared the output of the old and new
implementations to ensure they matched. Ran across several different data sets.
Output matched though the stddevs sometimes deviated after 3 decimal points.