### PR TITLE
Get config id even with no config values

### DIFF
--- a/ndustrialio/workertools/__init__.py
+++ b/ndustrialio/workertools/__init__.py
@@ -58,6 +58,8 @@ class BaseWorker(ConfiguredComponent):
         configValues = self.contxt.getConfigurationByClient(self.env)
         config = {}
 
+        self.configuration_id = configValues['id']
+
         for value in configValues['ConfigurationValues']:
 
             configValue = {}
@@ -78,8 +80,6 @@ class BaseWorker(ConfiguredComponent):
 
             # store config dict
             config[value['key']] = configValue
-
-            self.configuration_id = value['configuration_id']
 
         return config
 


### PR DESCRIPTION
Make configuration ID available without the presence of any configuration values.  Any calls to put/update a configuration value would fail due to configuration ID being `None`, since it was set in the configuration value loop. 