### PR TITLE
Fixes issue with room creation function

### DIFF
--- a/ndustrialio/apiservices/flywheeling.py
+++ b/ndustrialio/apiservices/flywheeling.py
@@ -194,7 +194,6 @@ class FlywheelingService(Service):
         assert isinstance(label, str)
         assert isinstance(name, str)
 
-        body = {'facility_id': facility_id,
-                'name': name,
+        body = {'name': name,
                 'label': label}
         return self.execute(POST(uri='systems/{}/rooms').format(system_id).body(body), execute)


### PR DESCRIPTION
# Why?
This function was setting a `facility_id` which is not needed to create a room in the Flywheeling API. It should be removed. (Reported from Alex @ Lineage)

See the Node.js controller if you'd like to see what fields are being used:
https://github.com/lineageanalytics/flywheeling-api/blob/master/controllers/rooms.js