### PR TITLE
Adds health service for reporting health of an asset

### DIFF
--- a/ndustrialio/apiservices/health.py
+++ b/ndustrialio/apiservices/health.py
@@ -1,0 +1,30 @@
+from enum import Enum
+from datetime import datetime
+
+from ndustrialio.apiservices import Service, POST
+
+
+class HealthStatus(Enum):
+    GOOD = 'healthy'
+    BAD = 'unhealthy'
+
+
+class HealthService(Service):
+
+    def __init__(self, client_id, client_secret=None):
+        super(HealthService, self).__init__(client_id, client_secret)
+
+    def baseURL(self):
+        return 'https://health.api.ndustrial.io/v1'
+
+    def audience(self):
+        return '6uaQIV1KnnWhXiTm09iGDvy2aQaz2xVI'
+
+    def report(self, org_id, asset_id, status=HealthStatus.GOOD, timestamp=datetime.now(), execute=True):
+        body = {
+            status: status,
+            timestamp: timestamp
+        }
+
+        return self.execute(POST(uri='{}/assets/{}'.format(org_id, asset_id))
+                            .body(body))

--- a/ndustrialio/apiservices/health.py
+++ b/ndustrialio/apiservices/health.py
@@ -20,7 +20,7 @@ class HealthService(Service):
     def audience(self):
         return '6uaQIV1KnnWhXiTm09iGDvy2aQaz2xVI'
 
-    def report(self, org_id, asset_id, status=HealthStatus.GOOD, timestamp=datetime.now(), execute=True):
+    def report(self, org_id, asset_id, status=HealthStatus.GOOD, timestamp=datetime.utcnow().isoformat(), execute=True):
         body = {
             status: status,
             timestamp: timestamp

--- a/ndustrialio/apiservices/health.py
+++ b/ndustrialio/apiservices/health.py
@@ -21,7 +21,7 @@ class HealthService(Service):
     def audience(self):
         return '6uaQIV1KnnWhXiTm09iGDvy2aQaz2xVI'
 
-    def report(self, org_id, asset_id, status=HealthStatus.GOOD, timestamp=datetime.utcnow().isoformat(), execute=True):
+    def report(self, org_id, asset_id, status=HealthStatus.GOOD, timestamp=datetime.now(tz=UTC).isoformat(), execute=True):
         body = {
             status: status,
             timestamp: timestamp

--- a/ndustrialio/apiservices/health.py
+++ b/ndustrialio/apiservices/health.py
@@ -1,5 +1,6 @@
 from enum import Enum
 from datetime import datetime
+from pytz import UTC
 
 from ndustrialio.apiservices import Service, POST
 


### PR DESCRIPTION
### Why?

The [Feed Status Service](https://github.com/ndustrialio/feed-status-service) needs to be able to report the health status of feeds and their fields to the new [Health Service](https://github.com/ndustrialio/health-api)

### What?
- Added `HealthService` class
- Added `HealthStatus` enum